### PR TITLE
Fix wrong output when recipe does not use `amount` but amount_min + amount_max + probability instead

### DIFF
--- a/prototypes/shared.lua
+++ b/prototypes/shared.lua
@@ -84,7 +84,7 @@ function ACT.getProductionNumbersForEntity(entity, playerIndex)
             production.summary_products[i] = {
                 name = ing.name,
                 spritePath = ing.type .. "/" .. ing.name,
-                amount =(ing.extra or ing.amount or ing.amount_max)  * (baseProductsPerSecond + (baseProductsPerSecond* production.effects.productivity.bonus)),
+                amount = (ing.extra or ing.amount or (ing.probability * 0.5 * (ing.amount_min + ing.amount_max))  * (baseProductsPerSecond + (baseProductsPerSecond* production.effects.productivity.bonus)),
                 type = ing.type
             }
         end

--- a/prototypes/shared.lua
+++ b/prototypes/shared.lua
@@ -84,7 +84,7 @@ function ACT.getProductionNumbersForEntity(entity, playerIndex)
             production.summary_products[i] = {
                 name = ing.name,
                 spritePath = ing.type .. "/" .. ing.name,
-                amount = (ing.extra or ing.amount or (ing.probability * 0.5 * (ing.amount_min + ing.amount_max))  * (baseProductsPerSecond + (baseProductsPerSecond* production.effects.productivity.bonus)),
+                amount = (ing.extra or ing.amount or (ing.probability * 0.5 * (ing.amount_min + ing.amount_max)))  * (baseProductsPerSecond + (baseProductsPerSecond* production.effects.productivity.bonus)),
                 type = ing.type
             }
         end


### PR DESCRIPTION
Per doc ( https://lua-api.factorio.com/latest/concepts.html#Product ), whenever amount is not used, then all the other 3 must be used.

In the current code, amount_max is used but amount_min is ignored and so is probablity.

I tested it to make sure it works and here is the result.

![image](https://github.com/Pawz777/actual-craft-times-remade/assets/650065/c94e9d66-8858-4a7f-8171-7fcc6a227fef)

Bug was here: https://github.com/Pawz777/actual-craft-times-remade/issues/2