### PR TITLE
feat: add option to select time interval

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,8 @@
 ---------------------------------------------------------------------------------------------------
+Version: 1.0.7
+  Features:
+    - Add option to select interval (time units) from seconds up to days
+---------------------------------------------------------------------------------------------------
 Version: 1.0.6
   Fixes:
     - Update to Factorio version 1.1

--- a/info.json
+++ b/info.json
@@ -1,10 +1,10 @@
 {
   "name": "actual-craft-times-remade",
   "author": "Pawz",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "title": "Actual Craft Times Remade",
   "homepage": "",
-  "description": "Indicates the number of items per second a machine consumes and produces",
+  "description": "Indicates the rate of items a machine consumes and produces",
   "factorio_version": "1.1",
   "dependencies": ["base >= 0.18.00"]
 }

--- a/locale/en/en.cfg
+++ b/locale/en/en.cfg
@@ -3,6 +3,8 @@ ACTR_mod_button=Toggle Actual Crafting Time Calculator
 
 [mod-setting-name]
 ACTR-Multiplier=Multiplier Range
+ACTR-Interval=Time Interval
 
 [mod-setting-description]
 ACTR-Multiplier=Set the max value for the multiplier slider in the Production Calculator
+ACTR-Interval=Show values as per this unit of time

--- a/prototypes/calculator.lua
+++ b/prototypes/calculator.lua
@@ -1,6 +1,13 @@
 local ACTR = require("prototypes.shared")
 local Calculator = {}
 
+local INTERVAL_MULTIPLIER = {
+    ["second"] = 1,
+    ["minute"] = 60,
+    ["hour"]   = 60*60,
+    ["day"]    = 3600*24,
+}
+
 --- Round a number.
 function round(val, decimal)
     local exp = decimal and 10 ^ decimal or 1
@@ -22,7 +29,7 @@ local function addListItem(gui_element, text, value, spritePath)
         cont.add {type = "sprite", sprite = spritePath, style = "ACTR_small_sprite"}
 
         cont.add {type = "label", caption = text}
-        cont.add {type = "label", caption = round(value, 2) .. " /s"}
+        cont.add {type = "label", caption = value}
     end
 end
 -- Adds to a 3 column table of ingredients
@@ -30,7 +37,7 @@ local function addIngredientRow(gui_element, text, value, spritePath)
     if (gui_element and gui_element.valid) then
         gui_element.add {type = "sprite", sprite = spritePath, style = "ACTR_small_sprite"}
         gui_element.add {type = "label", caption = text, style = "bold_label"}
-        gui_element.add {type = "label", caption = round(value, 2) .. " /s"}
+        gui_element.add {type = "label", caption = value}
     end
 end
 
@@ -38,6 +45,8 @@ local function createProductionDetailsInElement(gui_element, entity, playerIndex
     local production = ACTR.getProductionNumbersForEntity(entity, playerIndex)
     local player = game.players[playerIndex]
     if production then
+        local interval = settings.get_player_settings(player)["ACTR-Interval"].value or "second"
+        local suffix = " /".. interval:sub(1, 1)
         productionFlow = gui_element.add {type = "flow", direction = "horizontal", name = entity.unit_number .. "_productionFlow"}
         recipeFlow = productionFlow.add {type = "flow", direction = "horizontal", name = entity.unit_number .. "_recipeFlow"}
         if (production.summary_ingredients) then
@@ -47,7 +56,7 @@ local function createProductionDetailsInElement(gui_element, entity, playerIndex
             for i = 1, #production.summary_ingredients do
                 local ingredient = production.summary_ingredients[i]
                 local sprite = getValidSprite(player, ingredient.spritePath)
-                local amount = ingredient.amount * multiplier
+                local amount = round(ingredient.amount * multiplier * INTERVAL_MULTIPLIER[interval], 2) .. suffix
                 local name = game[ingredient.type .. "_prototypes"][ingredient.name].localised_name
 
                 addIngredientRow(container, name, amount, sprite)
@@ -60,7 +69,7 @@ local function createProductionDetailsInElement(gui_element, entity, playerIndex
             for i = 1, #production.summary_products do
                 local prod = production.summary_products[i]
                 local sprite = getValidSprite(player, prod.spritePath)
-                local amount = prod.amount * multiplier
+                local amount = round(prod.amount * multiplier * INTERVAL_MULTIPLIER[interval], 2) .. suffix
                 local name = game[prod.type .. "_prototypes"][prod.name].localised_name
                 addIngredientRow(container, name, amount, sprite)
             end

--- a/settings.lua
+++ b/settings.lua
@@ -5,5 +5,12 @@ data:extend({
     setting_type = 'runtime-per-user',
     minimum_value = 1,
     default_value = 100
-}}
-)
+},
+{
+    type = "string-setting",
+    name = "ACTR-Interval",
+    setting_type = 'runtime-per-user',
+    allowed_values = { "second", "minute", "hour", "day" },
+    default_value = "second",
+},
+})


### PR DESCRIPTION
self-describing, i hope...
now it's very easy to change to your preferred time scale (per player), so you can see human-readable production numbers for long cycles/recipes

also, closes this 4 years old discussion https://mods.factorio.com/mod/actual-craft-times-remade/discussion/5cc56338073cd9000cddff91  :)